### PR TITLE
Smoothly transitioning between stars and polygons with varying number of points

### DIFF
--- a/player/js/utils/PolynomialBezier.js
+++ b/player/js/utils/PolynomialBezier.js
@@ -304,4 +304,5 @@ export {
   pointEqual,
   floatEqual,
   tangentDirection,
+  lerp,
 };


### PR DESCRIPTION
### Goal

- Determine a drawing algorithm that gives a result as close to After Effects as possible when changing the number of points for polygons and stars
- Should work with varying inner and outer roundness!
- It should be completely unnoticeable when a new point appears for polygons (i.e. the rounding doesn't drastically change from one frame to the next)
- Unify all the players to this algorithm (after we have agreed on one..)

Looks pretty smooth!

https://github.com/lottielab/lottie-web/assets/100429762/e2ace4dc-b796-4ac9-ba6a-2bc29191afba


